### PR TITLE
[feat] Added DTO pattern and UserDefaults

### DIFF
--- a/Quick-Kick/Managers/KickboardDTO.swift
+++ b/Quick-Kick/Managers/KickboardDTO.swift
@@ -1,0 +1,33 @@
+//
+//  KickboardDTO.swift
+//  Quick-Kick
+//
+//  Created by 반성준 on 12/19/24.
+//
+
+import CoreData
+
+struct KickboardDTO: EntityTransformAble {
+    let nickName: String
+    let isSaddled: Bool
+    let isOccupied: Bool
+    let startTime: Date?
+    let endTime: Date?
+    let latitude: Double
+    let longitude: Double
+    let address: String
+
+    func toEntity(context: NSManagedObjectContext) -> Kickboard {
+        let description = NSEntityDescription.entity(forEntityName: String(describing: Kickboard.self), in: context)!
+        let entity = Kickboard(entity: description, insertInto: context)
+        entity.nickName = nickName
+        entity.isSaddled = isSaddled
+        entity.isOccupied = isOccupied
+        entity.startTime = startTime
+        entity.endTime = endTime
+        entity.latitude = latitude
+        entity.longitude = longitude
+        entity.address = address
+        return entity
+    }
+}

--- a/Quick-Kick/Managers/KickboardDataManageable.swift
+++ b/Quick-Kick/Managers/KickboardDataManageable.swift
@@ -9,6 +9,7 @@ import CoreData
 
 // MARK: - KickboardDataManageable Protocol
 protocol KickboardDataManageable {
+    var context: NSManagedObjectContext { get }
     func createKickboard(nickName: String,
                          isSaddled: Bool,
                          isOccupied: Bool,
@@ -20,4 +21,47 @@ protocol KickboardDataManageable {
     func fetchKickboards() -> [Kickboard]
     func deleteKickboard(_ kickboard: Kickboard)
     func saveContext()
+}
+
+// MARK: - Default Implementations
+extension KickboardDataManageable {
+    func createKickboard(nickName: String,
+                         isSaddled: Bool,
+                         isOccupied: Bool = false,
+                         startTime: Date? = nil,
+                         endTime: Date? = nil,
+                         latitude: Double,
+                         longitude: Double,
+                         address: String) {
+        let newKickboard = Kickboard(context: context)
+        newKickboard.nickName = nickName
+        newKickboard.isSaddled = isSaddled
+        newKickboard.isOccupied = isOccupied
+        newKickboard.startTime = startTime
+        newKickboard.endTime = endTime
+        newKickboard.latitude = latitude
+        newKickboard.longitude = longitude
+        newKickboard.address = address
+        saveContext()
+    }
+    
+    func fetchKickboards() -> [Kickboard] {
+        let request: NSFetchRequest<Kickboard> = Kickboard.fetchRequest()
+        return (try? context.fetch(request)) ?? []
+    }
+    
+    func deleteKickboard(_ kickboard: Kickboard) {
+        context.delete(kickboard)
+        saveContext()
+    }
+    
+    func saveContext() {
+        if context.hasChanges {
+            do {
+                try context.save()
+            } catch {
+                print("Error saving context: \(error.localizedDescription)")
+            }
+        }
+    }
 }

--- a/Quick-Kick/Managers/UserDefaultsManager.swift
+++ b/Quick-Kick/Managers/UserDefaultsManager.swift
@@ -2,10 +2,18 @@
 //  UserDefaultsManager.swift
 //  Quick-Kick
 //
-//  Created by 반성준 on 12/18/24.
+//  Created by 반성준 on 12/16/24.
 //
 
 import Foundation
+
+// MARK: - Key 관리 구조체
+struct UserDefaultsKeys {
+    static let user = "user"
+    static let loginStatus = "LoginStatus"
+    static let autoLoginOption = "AutoLoginOption"
+    static let rememberIDOption = "RememberIDOption"
+}
 
 // MARK: - Protocol
 protocol UserDataManageable {
@@ -21,12 +29,12 @@ protocol UserDataManageable {
 extension UserDataManageable {
     func saveUser(_ user: User) {
         if let encoded = try? JSONEncoder().encode(user) {
-            UserDefaults.standard.set(encoded, forKey: "user")
+            UserDefaults.standard.set(encoded, forKey: UserDefaultsKeys.user)
         }
     }
 
     func getUser() -> User? {
-        if let data = UserDefaults.standard.data(forKey: "user"),
+        if let data = UserDefaults.standard.data(forKey: UserDefaultsKeys.user),
            let user = try? JSONDecoder().decode(User.self, from: data) {
             return user
         }
@@ -34,22 +42,22 @@ extension UserDataManageable {
     }
 
     func setLoggedOut() {
-        UserDefaults.standard.set(false, forKey: "LoginStatus")
+        UserDefaults.standard.set(false, forKey: UserDefaultsKeys.loginStatus)
     }
 
     var isLoggedIn: Bool {
-        get { UserDefaults.standard.bool(forKey: "LoginStatus") }
-        set { UserDefaults.standard.set(newValue, forKey: "LoginStatus") }
+        get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.loginStatus) }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.loginStatus) }
     }
 
     var autoLoginOption: Bool {
-        get { UserDefaults.standard.bool(forKey: "AutoLoginOption") }
-        set { UserDefaults.standard.set(newValue, forKey: "AutoLoginOption") }
+        get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.autoLoginOption) }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.autoLoginOption) }
     }
 
     var rememberIDOption: Bool {
-        get { UserDefaults.standard.bool(forKey: "RememberIDOption") }
-        set { UserDefaults.standard.set(newValue, forKey: "RememberIDOption") }
+        get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.rememberIDOption) }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.rememberIDOption) }
     }
 }
 

--- a/Quick-Kick/Managers/UserDefaultsManager.swift
+++ b/Quick-Kick/Managers/UserDefaultsManager.swift
@@ -7,8 +7,8 @@
 
 import Foundation
 
-// MARK: - Key 관리 구조체
-struct UserDefaultsKeys {
+// MARK: - Key 관리 열거형
+enum UserDefaultsKeys {
     static let user = "user"
     static let loginStatus = "LoginStatus"
     static let autoLoginOption = "AutoLoginOption"

--- a/Quick-Kick/Model/Kickboard+CoreDataProperties.swift
+++ b/Quick-Kick/Model/Kickboard+CoreDataProperties.swift
@@ -5,7 +5,6 @@
 //  Created by 반성준 on 12/18/24.
 //
 
-import Foundation
 import CoreData
 
 @objc(Kickboard)
@@ -26,4 +25,18 @@ extension Kickboard {
     @NSManaged public var address: String
 }
 
-extension Kickboard: Identifiable {}
+// MARK: - Kickboard Extension for DTO
+extension Kickboard {
+    func toDTO() -> KickboardDTO {
+        return KickboardDTO(
+            nickName: self.nickName,
+            isSaddled: self.isSaddled,
+            isOccupied: self.isOccupied,
+            startTime: self.startTime,
+            endTime: self.endTime,
+            latitude: self.latitude,
+            longitude: self.longitude,
+            address: self.address
+        )
+    }
+}

--- a/Quick-Kick/ViewContorller/KickboardEditViewController.swift
+++ b/Quick-Kick/ViewContorller/KickboardEditViewController.swift
@@ -50,10 +50,13 @@ class KickboardEditViewController: UIViewController {
         kickboard.setValue(updatedAddress, forKey: #keyPath(Kickboard.address))
         kickboard.setValue(kickboardEditView.saddledSwitch.isOn, forKey: #keyPath(Kickboard.isSaddled))
 
-        CoreDataManager.shared.saveContext()
-        
-        print("킥보드 수정됨: \(updatedName), \(updatedAddress), \(kickboard.isSaddled ? "안장형" : "일반형")")
-        navigationController?.popViewController(animated: true)
+        do {
+            try CoreDataManager.shared.saveContext()
+            print("킥보드 수정됨: \(updatedName), \(updatedAddress), \(kickboard.isSaddled ? "안장형" : "일반형")")
+            navigationController?.popViewController(animated: true)
+        } catch {
+            print("Error saving context: \(error.localizedDescription)")
+        }
     }
     
     @objc private func deleteButtonTapped() {
@@ -62,7 +65,7 @@ class KickboardEditViewController: UIViewController {
         let alert = UIAlertController(title: "삭제", message: "킥보드를 삭제하시겠습니까?", preferredStyle: .alert)
         alert.addAction(UIAlertAction(title: "취소", style: .cancel))
         alert.addAction(UIAlertAction(title: "삭제", style: .destructive, handler: { _ in
-            CoreDataManager.shared.deleteKickboard(kickboard)
+            CoreDataManager.shared.delete(kickboard)
             print("킥보드 삭제됨")
             self.navigationController?.popViewController(animated: true)
         }))


### PR DESCRIPTION
# 개요
UserDefaults 데이터 관리 방식을 개선하고 DTO(Data Transfer Object) 패턴을 적용하여 Core Data와의 데이터 전환 로직을 최적화하였습니다. 이로 인해 데이터 관리의 명확성과 재사용성이 증가했습니다.

## 에러 드리블
1. UserDefaults Key 관리 문제
문제: UserDefaults 키를 문자열로 직접 사용하여 발생할 수 있는 오타 및 유지보수 문제.
해결: UserDefaultsKeys struct를 추가하여 키를 체계적으로 관리.

2. DTO 사용 시 Entity 변환 문제
문제: DTO에서 Entity로 변환하는 로직이 중복되어 코드를 수정하기 어려움.
해결: EntityTransformAble 프로토콜을 도입해 DTO에서 Entity로 변환하는 방식을 통일.

3. CoreData fetchRequest 중복
문제: 각 ViewController에서 fetchRequest를 반복 작성하여 코드 중복 발생.
해결: CoreDataManager의 fetch() 메서드에서 일관된 fetch 로직 제공

## 추가 or 변경사항 
1. DTO 패턴 적용
KickboardDTO를 추가해 데이터를 Core Data Entity와 명확히 분리.
toEntity(context:) 메서드로 DTO -> Entity 변환 지원.

2. CoreDataManageable 프로토콜 추가
공통 데이터 관리 작업(생성, 조회, 삭제)을 프로토콜로 추상화.
다양한 Entity에도 재사용 가능하도록 설계.

3. UserDefaultsKeys 구조 추가
UserDefaults에서 사용하는 키를 UserDefaultsKeys struct로 정의.
키 이름 하드코딩 제거, 관리 효율성 증가.

4. CoreDataManager 리팩토링
Core Data 작업(create, fetch, delete)을 간소화하고 에러 처리를 추가.
프로토콜로 추상화해 일관된 데이터 관리 제공.
