### PR TITLE
feat: 킥보드 등록 탭 > 킥보드 등록 모달로 주소 데이터 전송

### DIFF
--- a/Quick-Kick/AddKickboard/AddKickboardView.swift
+++ b/Quick-Kick/AddKickboard/AddKickboardView.swift
@@ -95,6 +95,6 @@ class AddKickboardView: UIView {
     }
     
     @objc private func presentModal() {
-        self.modalViewDelegate?.presentModalVIew()
+        self.modalViewDelegate?.presentModalView(mapView.centerCoordinate.latitude, mapView.centerCoordinate.longitude, address: noticeView.address)
     }
 }

--- a/Quick-Kick/AddKickboard/AddKickboardViewController.swift
+++ b/Quick-Kick/AddKickboard/AddKickboardViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class AddKickboardViewController: UIViewController, ModalViewDelegate {
+class AddKickboardViewController: UIViewController {
     
     private let addressRepository: AddressRepository = .init()
     
@@ -24,7 +24,7 @@ class AddKickboardViewController: UIViewController, ModalViewDelegate {
     }
 }
 
-extension AddKickboardViewController: MapViewDelegate {
+extension AddKickboardViewController: MapViewDelegate, ModalViewDelegate {
     func requestNaverAddress(lat: String, lon: String) {
         addressRepository.fetchAddress(lat: lat, lon: lon)
     }

--- a/Quick-Kick/AddKickboard/ModalViewDelegate.swift
+++ b/Quick-Kick/AddKickboard/ModalViewDelegate.swift
@@ -9,7 +9,7 @@ import UIKit
 
 protocol ModalViewDelegate: AnyObject where Self: UIViewController {
         
-    func presentModalVIew()
+    func presentModalView(_ latitude: Double, _ longitude: Double, address: String)
     
     func editKickboardModalView()
     
@@ -17,7 +17,7 @@ protocol ModalViewDelegate: AnyObject where Self: UIViewController {
 
 extension ModalViewDelegate {
     
-    func presentModalVIew() {
+    func presentModalView(_ latitude: Double, _ longitude: Double, address: String) {
         let modalVC = RegistrationModalViewController()
         modalVC.modalPresentationStyle = .formSheet
         modalVC.sheetPresentationController?.preferredCornerRadius = 50

--- a/Quick-Kick/AddKickboard/NoticeView.swift
+++ b/Quick-Kick/AddKickboard/NoticeView.swift
@@ -30,12 +30,17 @@ class NoticeView: UIView {
     private lazy var addressLabel: UILabel = {
         let label = UILabel()
         
-        label.text = "서울 서초구 강남대로 110 메리츠타워"
+        label.text = "서울 강남구 강남대로 지하 396 강남역"
         label.font = .boldSystemFont(ofSize: 20)
         label.textAlignment = .center
         
         return label
     }()
+    
+    // address 값 전달용 계산 프로퍼티
+    var address: String {
+        addressLabel.text ?? ""
+    }
     
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/Quick-Kick/RegistrationModalView/Controller/RegistrationModalViewController.swift
+++ b/Quick-Kick/RegistrationModalView/Controller/RegistrationModalViewController.swift
@@ -11,6 +11,10 @@ import SnapKit
 // 킥보드 등록을 모달뷰 컨트롤러
 final class RegistrationModalViewController: UIViewController {
     
+    private var latitude: Double?
+    private var longitude: Double?
+    private var address: String?
+    
     private var _typeSeleted: Bool = false
     private var _haveNickNameText: Bool = false
     
@@ -27,6 +31,14 @@ final class RegistrationModalViewController: UIViewController {
         setupTypeButton()
         setupTextField()
         setupAddButton()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        /// 디버깅용 코드 - 주소값 잘 전달 받았는지 출력으로 확인
+        print(latitude)
+        print(longitude)
+        print(address)
     }
     
     // MARK: - RegistrationModalViewController UI Setting Method
@@ -71,6 +83,13 @@ final class RegistrationModalViewController: UIViewController {
     func editKickboardData(_ type: Bool, _ text: String) {
         self.typeButton.updateData(type)
         self.textField.updateData(text)
+    }
+    
+    /// 킥보드 등록 탭에서 + 버튼 눌렀을 때 주소 정보 전달 받는 메소드
+    func setAddressInfo(_ latitude: Double, _ longitude: Double, _ address: String) {
+        self.latitude = latitude
+        self.longitude = longitude
+        self.address = address
     }
 }
 


### PR DESCRIPTION
# 개요
![Screenshot 2024-12-19 at 15 16 22](https://github.com/user-attachments/assets/03a16eeb-a53a-4591-bc7b-90184039db79)
스크린샷은 `RegistrationModalViewController`를 띄웠을 때 `AddKickboardView`로부터 전달 받은 위치 데이터값을 출력한 모습입니다.
상경님이 작업해주신 `modal`의 `present` 코드에 파라미터로 전달하는 방식으로 구현했습니다.

## 에러 드리블
-

## 추가 or 변경사항 
- `ModalViewDelegate`의 `presentModalView` 함수 정의부에 파라미터가 추가되었습니다.
- `NoticeView`에 주소값을 전달해주기 위한 계산 프로퍼티 `address`가 추가되었습니다.
- `RegistrationModalViewController`에 데이터 값을 받기 위한 프로퍼티가 추가되었습니다.

close #38 