### PR TITLE
fix: 킥보드 탭 ui 버그 해결

### DIFF
--- a/Quick-Kick/AddKickboard/AddKickboardView.swift
+++ b/Quick-Kick/AddKickboard/AddKickboardView.swift
@@ -18,9 +18,11 @@ class AddKickboardView: UIView {
         let button = UIButton()
         
         button.tintColor = UIColor.PersonalNomal.nomal
+        button.backgroundColor = .systemBackground
         
-        let imageConfig = UIImage.SymbolConfiguration(pointSize: 70)
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 60)
         button.setImage(UIImage(systemName: "plus.circle.fill", withConfiguration: imageConfig), for: .normal)
+        button.imageView?.contentMode = .center
         
         return button
     }()
@@ -75,7 +77,7 @@ class AddKickboardView: UIView {
         
         addButton.snp.makeConstraints {
             $0.trailing.bottom.equalToSuperview().offset(-32)
-            $0.height.width.equalTo(70)
+            $0.height.width.equalTo(60)
         }
         
         centerPinImage.snp.makeConstraints {

--- a/Quick-Kick/AddKickboard/NoticeView.swift
+++ b/Quick-Kick/AddKickboard/NoticeView.swift
@@ -33,6 +33,7 @@ class NoticeView: UIView {
         label.text = "서울 강남구 강남대로 지하 396 강남역"
         label.font = .boldSystemFont(ofSize: 20)
         label.textAlignment = .center
+        label.adjustsFontSizeToFitWidth = true
         
         return label
     }()
@@ -70,6 +71,12 @@ class NoticeView: UIView {
         
         labelStackView.snp.makeConstraints {
             $0.centerX.centerY.equalToSuperview()
+            $0.leading.trailing.equalToSuperview()
+        }
+        
+        addressLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(8)
+            $0.trailing.equalToSuperview().offset(-8)
         }
     }
 }


### PR DESCRIPTION
# 개요
![Screenshot 2024-12-19 at 21 18 44](https://github.com/user-attachments/assets/bd2af863-2135-42e5-b954-464a7054d818)
![Screenshot 2024-12-19 at 21 20 28](https://github.com/user-attachments/assets/a1fda0e3-9508-4f93-b13e-01e07d49432f)
킥보드 탭 ui 버그 처리 완료

## 에러 드리블
- `addButton`의 경우, backgroundColor 지정 시 이미지 밖을 배경이 살짝 벗어나는 버그가 있었습니다.
```swift
button.imageView?.contentMode = .center
```
해당 코드로 해결하였습니다.
- `addressLabel`의 경우, 텍스트가 길어지면 흰색 컨테이너 밖을 벗어나는 버그가 있었습니다.
```swift
label.adjustsFontSizeToFitWidth = true
```
```swift
addressLabel.snp.makeConstraints {
    $0.leading.equalToSuperview().offset(8)
    $0.trailing.equalToSuperview().offset(-8)
}
```
해당 코드로 해결하였습니다.

## 추가 or 변경사항 
close #45 