### PR TITLE
feat: 내 킥보드 등록 기능 추가

### DIFF
--- a/Quick-Kick/AddKickboard/ModalViewDelegate.swift
+++ b/Quick-Kick/AddKickboard/ModalViewDelegate.swift
@@ -19,6 +19,7 @@ extension ModalViewDelegate {
     
     func presentModalView(_ latitude: Double, _ longitude: Double, address: String) {
         let modalVC = RegistrationModalViewController()
+        modalVC.setAddressInfo(latitude, longitude, address)
         modalVC.modalPresentationStyle = .formSheet
         modalVC.sheetPresentationController?.preferredCornerRadius = 50
         modalVC.sheetPresentationController?.detents = [.medium()]

--- a/Quick-Kick/RegistrationModalView/Model/RegistrationViewDelegate.swift
+++ b/Quick-Kick/RegistrationModalView/Model/RegistrationViewDelegate.swift
@@ -13,7 +13,12 @@ protocol RegistrationViewDelegate: AnyObject {
     var typeSeleted: Bool { get set } // 킥보드 타입이 선택되었는가?
     
     var haveNickNameText: Bool { get set } // 킥보드 별명이 입력되었는가?
-        
+    
+    var sendNickName: String? { get set } // 킥보드 이름 전달
+    
+    var kickboardType: Bool? { get set } // 킥보드 타입 전달
+            
     func activateButton() // 버튼 활성화
     
+    func savedKickboardData() // 킥보드 정보 저장
 }

--- a/Quick-Kick/RegistrationModalView/View/KickboardTypeButton.swift
+++ b/Quick-Kick/RegistrationModalView/View/KickboardTypeButton.swift
@@ -130,7 +130,6 @@ private extension KickboardTypeButton {
     
     /// 노말 타입의 버튼을 선택했을 때 작동할 메소드
     func selectedNormalButton() {
-        print(#function)
         if self.quickboardNormalTypeButton.isSelected {
             self.quickboardNormalTypeButton.backgroundColor = .clear
             self.quickboardNormalTypeButton.isSelected = false
@@ -139,6 +138,7 @@ private extension KickboardTypeButton {
             self.quickboardNormalTypeButton.backgroundColor = .PersonalLight.active
             self.quickboardNormalTypeButton.isSelected = true
             self.registrationDelegate?.typeSeleted = true
+            self.registrationDelegate?.kickboardType = false
         }
         
         self.quickboardSeatTypeButton.backgroundColor = .clear
@@ -148,7 +148,6 @@ private extension KickboardTypeButton {
     
     /// 안장 타입의 버튼을 선택했을 때 작동할 메소드
     func selectedSeatButton() {
-        print(#function)
         if self.quickboardSeatTypeButton.isSelected {
             self.quickboardSeatTypeButton.backgroundColor = .clear
             self.quickboardSeatTypeButton.isSelected = false
@@ -157,6 +156,7 @@ private extension KickboardTypeButton {
             self.quickboardSeatTypeButton.backgroundColor = .PersonalLight.active
             self.quickboardSeatTypeButton.isSelected = true
             self.registrationDelegate?.typeSeleted = true
+            self.registrationDelegate?.kickboardType = true
         }
         
         self.quickboardNormalTypeButton.backgroundColor = .clear

--- a/Quick-Kick/RegistrationModalView/View/RegistrationButton.swift
+++ b/Quick-Kick/RegistrationModalView/View/RegistrationButton.swift
@@ -13,6 +13,8 @@ final class RegistrationButton: UIView {
     
     private let addButton = UIButton()
     
+    weak var registrationDelegate: RegistrationViewDelegate?
+    
     // MARK: - RegistrationButton Initializer
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -43,6 +45,7 @@ final class RegistrationButton: UIView {
         case false:
             self.addButton.isEnabled = false
             self.addButton.backgroundColor = .PersonalLight.light
+            self.addButton.removeTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
         }
     }
 }
@@ -72,7 +75,6 @@ private extension RegistrationButton {
 @objc private extension RegistrationButton {
     /// 버튼을 눌렀을 때 액션
     func buttonTapped() {
-        // CoreData에 데이터 전달
-        print(#function)
+        self.registrationDelegate?.savedKickboardData()
     }
 }

--- a/Quick-Kick/RegistrationModalView/View/RegistrationTextField.swift
+++ b/Quick-Kick/RegistrationModalView/View/RegistrationTextField.swift
@@ -109,6 +109,7 @@ private extension RegistrationTextField {
         print(#function)
         if self.nickNameField.text?.count ?? 0 > 0 {
             self.registrationDelegate?.haveNickNameText = true
+            self.registrationDelegate?.sendNickName = self.nickNameField.text
         } else {
             self.registrationDelegate?.haveNickNameText = false
         }


### PR DESCRIPTION
# 개요

![Simulator Screenshot - iPhone 16 Pro - 2024-12-19 at 22 04 47](https://github.com/user-attachments/assets/13d3082c-31e8-46be-ba0a-f2a282c763b6)

- 킥보드 등록 페이지에서 모달뷰를 통해 킥보드를 등록하면 코어데이터에 데이터를 저장하는 기능 구현

## 에러 드리블

-

## 추가 or 변경사항 

- 모달뷰를 닫을 때 `Alert`을 통해 사용자에게 데이터가 저장됨을 표시해줌 

close #44 
