### PR TITLE
feat: 로그인&회원가입&온보딩

### DIFF
--- a/Quick-Kick/AppDelegate.swift
+++ b/Quick-Kick/AppDelegate.swift
@@ -22,8 +22,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     
     private func setInitialView() -> UIViewController {
+        print("isLoggedIn:\(UserDefaultsManager.shared.isLoggedIn)")
+        print("autoLoginOption:\(UserDefaultsManager.shared.autoLoginOption)")
         if UserDefaultsManager.shared.isLoggedIn {
-            return LoginViewController()
+            return ViewController()
         } else if UserDefaultsManager.shared.autoLoginOption {
             return ViewController()
         } else {

--- a/Quick-Kick/Extension/UIViewController+Ext.swift
+++ b/Quick-Kick/Extension/UIViewController+Ext.swift
@@ -1,0 +1,18 @@
+//
+//  UIViewController.swift
+//  Quick-Kick
+//
+//  Created by 황석현 on 12/19/24.
+//
+
+import UIKit
+
+extension UIViewController {
+    /// 간단한 경고창을 생성하는 함수
+    func showAlert(title: String = "경고", message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: nil)
+        alert.addAction(okAction)
+        self.present(alert, animated: true, completion: nil)
+    }
+}

--- a/Quick-Kick/Managers/UserDefaultsManager.swift
+++ b/Quick-Kick/Managers/UserDefaultsManager.swift
@@ -13,6 +13,7 @@ enum UserDefaultsKeys {
     static let loginStatus = "LoginStatus"
     static let autoLoginOption = "AutoLoginOption"
     static let rememberIDOption = "RememberIDOption"
+    static let onboarded = "Onboarded"
 }
 
 // MARK: - Protocol
@@ -22,6 +23,7 @@ protocol UserDataManageable {
     var isLoggedIn: Bool { get set }
     var autoLoginOption: Bool { get set }
     var rememberIDOption: Bool { get set }
+    var onboarded: Bool { get set }
     func setLoggedOut()
 }
 
@@ -72,6 +74,7 @@ struct User: Codable {
 
 // MARK: - UserDefaultsManager
 final class UserDefaultsManager: UserDataManageable {
+    
   static let shared = UserDefaultsManager()
   private init() {}
     var isLoggedIn: Bool {
@@ -87,5 +90,10 @@ final class UserDefaultsManager: UserDataManageable {
     var rememberIDOption: Bool {
         get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.rememberIDOption) }
         set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.rememberIDOption) }
+    }
+    
+    var onboarded: Bool {
+        get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.onboarded) }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.onboarded) }
     }
  }

--- a/Quick-Kick/OnboadingPage/OnboadingView/OnboardingPageView.swift
+++ b/Quick-Kick/OnboadingPage/OnboadingView/OnboardingPageView.swift
@@ -145,6 +145,7 @@ private extension OnboardingPageView {
     
     /// 뷰 컨트롤러를 바꾸는 메소드
     func changeViewController() {
+        UserDefaultsManager.shared.onboarded = true
         DispatchQueue.main.async {
             UIView.transition(with: self.window!, duration: 0.5, options: .transitionCrossDissolve) {
                 self.window?.rootViewController = UINavigationController(rootViewController: ViewController())

--- a/Quick-Kick/View/LoginView.swift
+++ b/Quick-Kick/View/LoginView.swift
@@ -205,12 +205,15 @@ extension LoginView {
         if let email = emailField.text, let password = passwordField.text {
             delegate?.didLoginButtonTapped(email, password)
         }
+    }
+    func showOnboardingPage() {
         DispatchQueue.main.async {
             UIView.transition(with: self.window!, duration: 0.5, options: .transitionCrossDissolve) {
                 self.window?.rootViewController = UINavigationController(rootViewController: OnboardingPageViewController())
             }
         }
     }
+    
     // 회원가입 터치
     @objc func signupButtonTapped() {
         delegate?.didSignUpButtonTapped()

--- a/Quick-Kick/View/LoginView.swift
+++ b/Quick-Kick/View/LoginView.swift
@@ -20,16 +20,14 @@ class LoginView: UIView {
     }()
     private let emailField = UITextField().setCustomPlaceholder(placeholder: "이메일")
     private let passwordField = UITextField().setCustomPlaceholder(placeholder: "비밀번호")
-    
-    private let rememberIDOption: UIButton = {
-        let button = UIButton()
-        button.setTitle("아이디 저장", for: .normal)
-        button.setTitleColor(.systemGray, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 12)
-        button.setTitleColor(UIColor.PersonalNomal.nomal, for: .normal)
-        return button
+    private let rememberIDOption = UIView()
+    private let rememberIDOptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "아이디 저장"
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = UIColor.PersonalNomal.nomal
+        return label
     }()
-    
     private let rememberIDCheckBox: UIImageView = {
         let image = UIImage(systemName: "square")
         let imageView = UIImageView(image: image)
@@ -37,13 +35,14 @@ class LoginView: UIView {
         imageView.tintColor = UIColor.PersonalNomal.nomal
         return imageView
     }()
-    private let autoLoginOption: UIButton = {
-        let button = UIButton()
-        button.setTitle("자동 로그인", for: .normal)
-        button.setTitleColor(.systemGray, for: .normal)
-        button.titleLabel?.font = .systemFont(ofSize: 12)
-        button.setTitleColor(UIColor.PersonalNomal.nomal, for: .normal)
-        return button
+    private let autoLoginOption = UIView()
+    
+    private let autoLoginOptionLabel: UILabel = {
+        let label = UILabel()
+        label.text = "자동 로그인"
+        label.font = .systemFont(ofSize: 12)
+        label.textColor = UIColor.PersonalNomal.nomal
+        return label
     }()
     private lazy var autoLoginCheckBox: UIImageView = {
         let image = UIImage(systemName: "square")
@@ -101,7 +100,17 @@ class LoginView: UIView {
 // MARK: - Layout
 extension LoginView {
     private func setupSubviews() {
-        [logoImageView, emailField, passwordField, rememberIDCheckBox, autoLoginOption, autoLoginCheckBox, rememberIDOption, loginButton, signupButton]
+        [rememberIDCheckBox, rememberIDOptionLabel]
+            .forEach{ rememberIDOption.addSubview($0) }
+        [autoLoginCheckBox, autoLoginOptionLabel]
+            .forEach{ autoLoginOption.addSubview($0) }
+        [logoImageView,
+         emailField,
+         passwordField,
+         rememberIDOption,
+         autoLoginOption,
+         loginButton,
+         signupButton]
             .forEach{ addSubview($0) }
         layout()
     }
@@ -133,30 +142,45 @@ extension LoginView {
         autoLoginOption.snp.makeConstraints { make in
             make.top.equalTo(passwordField.snp.bottom).offset(10)
             make.left.equalTo(passwordField.snp.left)
+            make.width.equalTo(80)
+            make.height.equalTo(20)
+        }
+        
+        autoLoginOptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(passwordField.snp.bottom).offset(10)
+            make.left.equalTo(passwordField.snp.left)
             make.width.equalTo(60)
             make.height.equalTo(20)
         }
         
         autoLoginCheckBox.snp.makeConstraints { make in
-            make.top.equalTo(passwordField.snp.bottom).offset(10)
-            make.left.equalTo(autoLoginOption.snp.right)
+            make.top.equalTo(autoLoginOption.snp.top)
+            make.left.equalTo(autoLoginOptionLabel.snp.right)
             make.size.equalTo(20)
         }
         autoLoginCheckBox.image = UIImage(systemName: autoLoginCheckBoxIsChecked ? "checkmark.square.fill" : "square")
         
+        rememberIDOption.snp.makeConstraints { make in
+            make.top.equalTo(passwordField.snp.bottom).offset(10)
+            make.left.equalTo(autoLoginOption.snp.right).offset(10)
+            make.width.equalTo(80)
+            make.height.equalTo(20)
+        }
+        
+        rememberIDOptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(passwordField.snp.bottom).offset(10)
+            make.left.equalTo(rememberIDOption.snp.left)
+            make.width.equalTo(60)
+            make.height.equalTo(20)
+        }
+        
         rememberIDCheckBox.snp.makeConstraints { make in
             make.top.equalTo(passwordField.snp.bottom).offset(10)
-            make.left.equalTo(rememberIDOption.snp.right)
+            make.left.equalTo(rememberIDOptionLabel.snp.right)
             make.size.equalTo(20)
         }
         rememberIDCheckBox.image = UIImage(systemName: rememberIDCheckBoxIsChecked ? "checkmark.square.fill" : "square")
         
-        rememberIDOption.snp.makeConstraints { make in
-            make.top.equalTo(passwordField.snp.bottom).offset(10)
-            make.left.equalTo(autoLoginCheckBox.snp.right)
-            make.width.equalTo(60)
-            make.height.equalTo(20)
-        }
         
         loginButton.snp.makeConstraints { make in
             make.top.equalTo(rememberIDOption.snp.bottom).offset(100)
@@ -177,8 +201,10 @@ extension LoginView {
 extension LoginView {
     // 버튼 타겟추가
     private func settingActions() {
-        autoLoginOption.addTarget(self, action: #selector(autoLoginOptionTapped), for: .touchUpInside)
-        rememberIDOption.addTarget(self, action: #selector(rememberIDOptionTapped), for: .touchUpInside)
+        let autoLoginOptionTapGesture = UITapGestureRecognizer(target: self, action: #selector(autoLoginOptionTapped))
+        let rememberIDOptionTapGesture = UITapGestureRecognizer(target: self, action: #selector(rememberIDOptionTapped))
+        autoLoginOption.addGestureRecognizer(autoLoginOptionTapGesture)
+        rememberIDOption.addGestureRecognizer(rememberIDOptionTapGesture)
         loginButton.addTarget(self, action: #selector(loginButtonTapped), for: .touchUpInside)
         signupButton.addTarget(self, action: #selector(signupButtonTapped), for: .touchUpInside)
     }

--- a/Quick-Kick/ViewContorller/LoginViewController.swift
+++ b/Quick-Kick/ViewContorller/LoginViewController.swift
@@ -26,10 +26,13 @@ class LoginViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        navigationItem.hidesBackButton = true
+        navigationItem.hidesBackButton = false
         view.backgroundColor = .systemBackground
         let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
         view.addGestureRecognizer(tapGesture)
+        let backButton = UIBarButtonItem(title: "뒤로 가기", style: .plain, target: nil, action: nil)
+        backButton.tintColor = UIColor.PersonalNomal.nomal
+        navigationItem.backBarButtonItem = backButton
         printUserInfoStatus()
         processAuthOption()
     }
@@ -49,10 +52,7 @@ extension LoginViewController: LoginViewDelegate {
             login()
             loginView.showOnboardingPage()
         } else {
-            let alert = UIAlertController(title: "로그인 실패", message: "입력값을 확인해주세요.", preferredStyle: .alert)
-            let okAction = UIAlertAction(title: "OK", style: .default)
-            alert.addAction(okAction)
-            self.present(alert, animated: true)
+            showAlert(message: "입력 값을 확인해주세요!")
             print("로그인 실패")
             initTextFields()
         }
@@ -88,7 +88,6 @@ extension LoginViewController: LoginViewDelegate {
     func didSignUpButtonTapped() {
         print("회원가입 화면으로 이동")
         let signUpVC = SignUpViewController()
-        signUpVC.navigationItem.hidesBackButton = true
         navigationController?.pushViewController(signUpVC, animated: true)
     }
 }

--- a/Quick-Kick/ViewContorller/LoginViewController.swift
+++ b/Quick-Kick/ViewContorller/LoginViewController.swift
@@ -47,8 +47,14 @@ extension LoginViewController: LoginViewDelegate {
     func didLoginButtonTapped(_ email: String, _ password: String) {
         if isCorrectInfo(email: email, password: password) {
             login()
+            loginView.showOnboardingPage()
         } else {
+            let alert = UIAlertController(title: "로그인 실패", message: "입력값을 확인해주세요.", preferredStyle: .alert)
+            let okAction = UIAlertAction(title: "OK", style: .default)
+            alert.addAction(okAction)
+            self.present(alert, animated: true)
             print("로그인 실패")
+            initTextFields()
         }
     }
     
@@ -107,7 +113,10 @@ extension LoginViewController {
         guard let email, let password else {
             print("정보를 입력해주세요")
             return false }
+        print("isCorrectInfo()")
         guard let user = UserDefaultsManager.shared.getUser() else { return false }
+        print("\(user.email), \(user.password)")
+        print("\(email), \(password)")
         if email == user.email && password == user.password {
             return true
         } else {

--- a/Quick-Kick/ViewContorller/SignUpViewController.swift
+++ b/Quick-Kick/ViewContorller/SignUpViewController.swift
@@ -27,12 +27,24 @@ class SignUpViewController: UIViewController {
 
 // MARK: - Delegate
 extension SignUpViewController: SignUpViewDelegate {
-    func didSignupButtonTapped(_ email: String, pass: String) {
-        UserDefaultsManager.shared.saveUser(User(email: email, password: pass))
-        if let targetVC = navigationController?.viewControllers.first(where: { $0 is LoginViewController }) {
-            navigationController?.popToViewController(targetVC, animated: true)
-        } else {
-            print("이동할 LoginViewController가 스택에 없음")
+    func didSignupButtonTapped(email: String, pass: String, type: SignUpType) {
+        switch type {
+        case .emptyInput:
+            showAlert(message: "정보를 입력해주세요!")
+        case .invalidEmail:
+            showAlert(message: "이메일을 확인해주세요!")
+        case .invalidPassword:
+            showAlert(message: "비밀번호를 4자리 이상 입력해주세요!")
+        case .wrongConfirmPassword:
+            showAlert(message: "비밀번호를 확인해주세요!")
+        case .success:
+            print("Success")
+            UserDefaultsManager.shared.saveUser(User(email: email, password: pass))
+            if let targetVC = navigationController?.viewControllers.first(where: { $0 is LoginViewController }) {
+                navigationController?.popToViewController(targetVC, animated: true)
+            } else {
+                print("이동할 LoginViewController가 스택에 없음")
+            }
         }
     }
 }


### PR DESCRIPTION
# 개요
<div>
<img width="250" src="https://github.com/user-attachments/assets/633e3a06-b858-480b-9ffc-070c7a4bdfbb">
<img width="250" src="https://github.com/user-attachments/assets/fd50c33d-b3cc-43fb-b3ff-2ab5b4748a07">
<img width="250" src="https://github.com/user-attachments/assets/c167f397-6093-449c-b278-b3d9e2e721a6">
</div>

## 에러 드리블
- 여러 상황에 맞는 경고문구를 출력하고 싶어서 `switch case`를 활용하여 구현해봤습니다.

## 추가 or 변경사항 
- 회원가입 화면에서 뒤로가기를 추가했습니다.
- 경고창 띄우는 기능이 추가되었습니다.
- 로그인 시 온보딩 화면으로 넘어갑니다.
- 온보딩화면에서 `시작하기` 누르면 `UserDefaults`에 온보딩 이력을 저장합니다.

close #52 