### PR TITLE
feat: 지도 터치 시 모달 뷰 내려가도록 구현, 모달 반납버튼 구현

### DIFF
--- a/Quick-Kick/AddKickboard/AddKickboardViewController.swift
+++ b/Quick-Kick/AddKickboard/AddKickboardViewController.swift
@@ -25,6 +25,17 @@ class AddKickboardViewController: UIViewController {
 }
 
 extension AddKickboardViewController: MapViewDelegate, ModalViewDelegate {
+    func editKickboardModalView() {
+        let modalVC = RegistrationModalViewController()
+        modalVC.editKickboardData(false, "Sparta의 킥보드") // 추후 코어데이터에서 데이터를 받아와서 입력
+        
+        modalVC.modalPresentationStyle = .formSheet
+        modalVC.sheetPresentationController?.preferredCornerRadius = 50
+        modalVC.sheetPresentationController?.detents = [.medium()]
+        
+        self.present(modalVC, animated: true)
+    }
+    
     func requestNaverAddress(lat: String, lon: String) {
         addressRepository.fetchAddress(lat: lat, lon: lon)
     }

--- a/Quick-Kick/AddKickboard/AddKickboardViewController.swift
+++ b/Quick-Kick/AddKickboard/AddKickboardViewController.swift
@@ -25,17 +25,6 @@ class AddKickboardViewController: UIViewController {
 }
 
 extension AddKickboardViewController: MapViewDelegate, ModalViewDelegate {
-    func editKickboardModalView() {
-        let modalVC = RegistrationModalViewController()
-        modalVC.editKickboardData(false, "Sparta의 킥보드") // 추후 코어데이터에서 데이터를 받아와서 입력
-        
-        modalVC.modalPresentationStyle = .formSheet
-        modalVC.sheetPresentationController?.preferredCornerRadius = 50
-        modalVC.sheetPresentationController?.detents = [.medium()]
-        
-        self.present(modalVC, animated: true)
-    }
-    
     func requestNaverAddress(lat: String, lon: String) {
         addressRepository.fetchAddress(lat: lat, lon: lon)
     }

--- a/Quick-Kick/AddKickboard/ModalViewDelegate.swift
+++ b/Quick-Kick/AddKickboard/ModalViewDelegate.swift
@@ -8,14 +8,24 @@
 import UIKit
 
 protocol ModalViewDelegate: AnyObject where Self: UIViewController {
-        
+    
     func presentModalView(_ latitude: Double, _ longitude: Double, address: String)
     
     func editKickboardModalView()
-        
+    
 }
 
 extension ModalViewDelegate {
+    func editKickboardModalView() {
+        let modalVC = RegistrationModalViewController()
+        modalVC.editKickboardData(false, "Sparta의 킥보드") // 추후 코어데이터에서 데이터를 받아와서 입력
+        
+        modalVC.modalPresentationStyle = .formSheet
+        modalVC.sheetPresentationController?.preferredCornerRadius = 50
+        modalVC.sheetPresentationController?.detents = [.medium()]
+        
+        self.present(modalVC, animated: true)
+    }
     
     func presentModalView(_ latitude: Double, _ longitude: Double, address: String) {
         let modalVC = RegistrationModalViewController()

--- a/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
+++ b/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
@@ -19,23 +19,5 @@ final class SearchKickboardViewController: UIViewController {
     private func fetchKickboards() {
         let kickboards = CoreDataManager.shared.fetch()
         searchKickboardView.deliverKickboardsData(kickboards)
-        makeMockData()
-    }
-}
-
-extension SearchKickboardViewController {
-    private func makeMockData() {
-        print(CoreDataManager.shared.fetch())
-        let data = KickboardDTO(
-            nickName: "씽씽이A",
-            isSaddled: false,
-            isOccupied: false,
-            startTime: nil,
-            endTime: nil,
-            latitude: 37.517430,
-            longitude: 127.047515,
-            address: "강남역 1번출구"
-        )
-        CoreDataManager.shared.create(with: data)
     }
 }

--- a/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
+++ b/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
@@ -8,32 +8,16 @@ import UIKit
 
 final class SearchKickboardViewController: UIViewController {
     let searchKickboardView = SearchKickboardView()
+    
     override func loadView() {
         super.loadView()
+        
+        fetchKickboards()
         view = searchKickboardView
     }
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    private func fetchKickboards() {
         let kickboards = CoreDataManager.shared.fetch()
         searchKickboardView.deliverKickboardsData(kickboards)
-//        makeMockData()
-    }
-}
-
-extension SearchKickboardViewController {
-    private func makeMockData() {
-        print(CoreDataManager.shared.fetch())
-        let data = KickboardDTO(
-            nickName: "씽씽이A",
-            isSaddled: false,
-            isOccupied: false,
-            startTime: nil,
-            endTime: nil,
-            latitude: 37.517430,
-            longitude: 127.047515,
-            address: "강남역 1번출구"
-        )
-        CoreDataManager.shared.create(with: data)
     }
 }

--- a/Quick-Kick/SearchKickboard/View/RentKickboardModalView.swift
+++ b/Quick-Kick/SearchKickboard/View/RentKickboardModalView.swift
@@ -7,7 +7,7 @@
 import UIKit
 
 final class RentKickboardModalView: UIView {
-    private var kickboard: Kickboard?
+    private(set) var kickboard: Kickboard?
     
     private let kickboardImageView: UIImageView = {
         let imageView = UIImageView()
@@ -60,9 +60,8 @@ final class RentKickboardModalView: UIView {
         return stackView
     }()
     
-    init(kickboard: Kickboard) {
-        super.init(frame: .zero)
-        self.kickboard = kickboard
+    override init(frame: CGRect) {
+        super.init(frame: frame)
         setupModalView()
         setupLayout()
     }
@@ -73,8 +72,6 @@ final class RentKickboardModalView: UIView {
     
     private func setupModalView() {
         self.backgroundColor = .white
-        self.kickboardNicknameLabel.text = self.kickboard?.nickName
-        self.kickboardLocationLabel.text = self.kickboard?.address
         self.rentButton.addTarget(self, action: #selector(rentButtonTapped), for: .touchUpInside)
     }
     
@@ -90,14 +87,23 @@ final class RentKickboardModalView: UIView {
         }
     }
     
+    func setupKickboardData(_ kickboard: Kickboard) {
+        self.kickboard = kickboard
+        self.kickboardNicknameLabel.text = kickboard.nickName
+        self.kickboardLocationLabel.text = kickboard.address
+        if kickboard.isSaddled {
+            self.kickboardImageView.image = UIImage(named: "QuickBoard - Seat")
+        }
+    }
+    
     @objc
     private func rentButtonTapped() {
         if self.kickboard?.startTime == nil {
             self.kickboard?.startTime = Date()
-            self.rentButton.titleLabel?.text = "이용 종료"
+            self.rentButton.setTitle("이용 종료", for: .normal)
         } else {
             self.kickboard?.endTime = Date()
-            self.rentButton.titleLabel?.text = "이용 시작"
+            self.rentButton.setTitle("이용 시작", for: .normal)
         }
     }
 }

--- a/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
+++ b/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
@@ -23,6 +23,7 @@ final class SearchKickboardMapView: MKMapView {
     
     private var kickboards: [Kickboard]?
     weak var mapViewDelegate: SearchKickboardMapViewDelegate?
+    private var rentKickboardModalView = RentKickboardModalView()
     
     private let gangnamStation = CLLocation(
         latitude: 37.498095,
@@ -129,21 +130,6 @@ extension SearchKickboardMapView: MKMapViewDelegate {
         return annotationView
     }
     
-    func mapView(_ mapView: MKMapView, didSelect annotation: MKAnnotation) {
-        if annotation is MKUserLocation {
-            return
-        }
-        guard let kickboardAnnotation = annotation as? KickboardAnnotation else { return }
-        let kickboard = kickboardAnnotation.kickboard
-        
-        let rentKickboardModalView = RentKickboardModalView(kickboard: kickboard)
-        self.addSubview(rentKickboardModalView)
-        rentKickboardModalView.snp.makeConstraints {
-            $0.bottom.equalToSuperview().offset(-10)
-            $0.leading.trailing.equalToSuperview().inset(10)
-        }
-    }
-    
     func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
         // 맵의 중심 좌표
         let mapCenter = CLLocation(latitude: mapView.centerCoordinate.latitude,
@@ -161,5 +147,63 @@ extension SearchKickboardMapView: MKMapViewDelegate {
                 mapViewDelegate?.hideLocationResetButton()
             }
         }
+    }
+}
+
+extension SearchKickboardMapView {
+    func mapView(_ mapView: MKMapView, didSelect annotation: MKAnnotation) {
+        if annotation is MKUserLocation {
+            return
+        }
+        guard let kickboardAnnotation = annotation as? KickboardAnnotation else { return }
+        let kickboard = kickboardAnnotation.kickboard
+        
+        // 모달뷰가 이미 올라와있고 && 같은 마커 클릭 경우
+        if rentKickboardModalView.superview != nil && rentKickboardModalView.kickboard?.nickName == kickboard.nickName {
+            return
+        }
+        
+        showModal(for: kickboard)
+    }
+    
+    private func showModal(for kickboard: Kickboard) {
+        rentKickboardModalView.setupKickboardData(kickboard)
+        self.addSubview(rentKickboardModalView)
+        rentKickboardModalView.snp.makeConstraints {
+            $0.bottom.equalToSuperview().offset(-10)
+            $0.leading.trailing.equalToSuperview().inset(10)
+        }
+    }
+    
+    override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        let hitView = super.hitTest(point, with: event)
+        
+        // 모달뷰가 표시된 상태인지(슈퍼뷰를 가지는지) 체크
+        if rentKickboardModalView.superview != nil {
+            // 터치가 모달뷰 내부인지 체크
+            let isModalTouch = hitView?.isDescendant(of: rentKickboardModalView) == true
+            
+            // 터치한 부분이 마커인지, 마커라면 KickboardAnnotation로 다운캐스팅이 되는지 체크
+            let isSelectedMarkerTouch = if let annotationView = hitView as? MKAnnotationView,
+                                           let annotation = annotationView.annotation as? KickboardAnnotation {
+                // 마커의 킥보드 닉네임과 모달의 킥보드 닉네임이 같은지 체크
+                annotation.kickboard.nickName == rentKickboardModalView.kickboard?.nickName
+            } else {
+                false
+            }
+            
+            // 킥보드 빌린 상태인지 체크
+            let isRented = rentKickboardModalView.kickboard?.startTime != nil
+            
+            // 모달뷰 내부이거나 현재 선택된 마커면 터치 그대로 흘려보내기
+            if isModalTouch || isSelectedMarkerTouch || isRented {
+                return hitView
+            } else {
+                // 그 외의 영역 터치시 모달 제거
+                rentKickboardModalView.removeFromSuperview()
+                return super.hitTest(point, with: event)
+            }
+        }
+        return hitView
     }
 }


### PR DESCRIPTION
# 개요
|지도 터치 시 모달뷰 내려가기|모달 이용시작/이용종료 버튼|
| --- | --- | 
| <img src="https://github.com/user-attachments/assets/05ef93b8-2a95-4232-ba72-7629ad864e2b" width="300"> | <img src="https://github.com/user-attachments/assets/c83512af-d7b8-4de7-b1b4-e3331f2f4785" width="300"> |


## 에러 드리블
- 버튼의 타이틀이 변경되지 않는 문제
 -> button.setTitle()으로 타이틀을 바꾸는 것이 아닌 button.titleLabel?.text로 값을 수정하고 있었음.
 -> button.setTitle()로 타이틀 수정


## 추가 or 변경사항 
- 모달 뷰 밖 영역 터치 시 모달이 removeFromSuperview() 되도록 수정
- 킥보드 이용 시작한 경우 버튼의 타이틀 '이용 시작' -> '이용 종료'로 수정
