### PR TITLE
[feat] 이용내역 더미

### DIFF
--- a/Quick-Kick/View/HistorySectionView.swift
+++ b/Quick-Kick/View/HistorySectionView.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 class HistorySectionView: UIView {
-    
+
     // MARK: - UI Components
     private let containerView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.PersonalLight.light
-        view.layer.cornerRadius = 20
+        view.layer.cornerRadius = 24
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()
@@ -28,7 +28,6 @@ class HistorySectionView: UIView {
     }()
     
     private var historyViews: [UIView] = []
-    private var histories: [Kickboard] = []
 
     // MARK: - Initialization
     override init(frame: CGRect) {
@@ -58,16 +57,15 @@ class HistorySectionView: UIView {
     }
     
     // MARK: - Configure Method
-    func configure(with histories: [Kickboard]) {
+    func configure(with histories: [(String, String)]) {
         // 기존 뷰 제거
         historyViews.forEach { $0.removeFromSuperview() }
         historyViews.removeAll()
 
-        self.histories = histories
         var previousView: UIView?
 
-        for kickboard in histories {
-            let historyView = createHistoryView(for: kickboard)
+        for history in histories {
+            let historyView = createHistoryView(date: history.0, time: history.1)
             historyView.translatesAutoresizingMaskIntoConstraints = false
             containerView.addSubview(historyView)
             
@@ -75,7 +73,7 @@ class HistorySectionView: UIView {
                 historyView.topAnchor.constraint(equalTo: previousView?.bottomAnchor ?? titleLabel.bottomAnchor, constant: 10),
                 historyView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
                 historyView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10),
-                historyView.heightAnchor.constraint(equalToConstant: 60)
+                historyView.heightAnchor.constraint(equalToConstant: 70)
             ])
             
             previousView = historyView
@@ -85,34 +83,43 @@ class HistorySectionView: UIView {
         previousView?.bottomAnchor.constraint(equalTo: containerView.bottomAnchor, constant: -10).isActive = true
     }
     
-    // MARK: - Create Individual History View
-    private func createHistoryView(for kickboard: Kickboard) -> UIView {
+    private func createHistoryView(date: String, time: String) -> UIView {
         let container = UIView()
         container.backgroundColor = .white
-        container.layer.cornerRadius = 10
+        container.layer.cornerRadius = 24
         container.layer.shadowColor = UIColor.black.withAlphaComponent(0.1).cgColor
         container.layer.shadowOpacity = 0.5
         container.layer.shadowOffset = CGSize(width: 0, height: 2)
         container.layer.shadowRadius = 4
         
+        let imageView = UIImageView(image: UIImage(named: "QuickBoard"))
+        imageView.contentMode = .scaleAspectFit
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        
         let dateLabel = UILabel()
-        dateLabel.text = formatDate(kickboard.startTime)
+        dateLabel.text = "날짜 \(date)"
         dateLabel.font = UIFont.boldSystemFont(ofSize: 14)
-        dateLabel.textColor = .systemPurple
+        dateLabel.textColor = .black
         dateLabel.translatesAutoresizingMaskIntoConstraints = false
         
         let timeLabel = UILabel()
-        timeLabel.text = "\(formatTime(kickboard.startTime)) - \(formatTime(kickboard.endTime))"
+        timeLabel.text = "운행 시간 \(time)"
         timeLabel.font = UIFont.systemFont(ofSize: 12)
         timeLabel.textColor = .darkGray
         timeLabel.translatesAutoresizingMaskIntoConstraints = false
-        
+
+        container.addSubview(imageView)
         container.addSubview(dateLabel)
         container.addSubview(timeLabel)
         
         NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 10),
+            imageView.centerYAnchor.constraint(equalTo: container.centerYAnchor),
+            imageView.widthAnchor.constraint(equalToConstant: 40),
+            imageView.heightAnchor.constraint(equalToConstant: 40),
+            
             dateLabel.topAnchor.constraint(equalTo: container.topAnchor, constant: 10),
-            dateLabel.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 10),
+            dateLabel.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 10),
             dateLabel.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -10),
             
             timeLabel.topAnchor.constraint(equalTo: dateLabel.bottomAnchor, constant: 5),
@@ -121,20 +128,5 @@ class HistorySectionView: UIView {
         ])
         
         return container
-    }
-    
-    // MARK: - Helpers
-    private func formatDate(_ date: Date?) -> String {
-        guard let date = date else { return "날짜 없음" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yy.MM.dd"
-        return formatter.string(from: date)
-    }
-    
-    private func formatTime(_ date: Date?) -> String {
-        guard let date = date else { return "시간 없음" }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "HH:mm"
-        return formatter.string(from: date)
     }
 }

--- a/Quick-Kick/View/KickboardSectionView.swift
+++ b/Quick-Kick/View/KickboardSectionView.swift
@@ -13,7 +13,7 @@ class KickboardSectionView: UIView {
     private let containerView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.PersonalLight.light
-        view.layer.cornerRadius = 32
+        view.layer.cornerRadius = 24
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/Quick-Kick/View/ProfileView.swift
+++ b/Quick-Kick/View/ProfileView.swift
@@ -14,7 +14,7 @@ class ProfileView: UIView {
     private let containerView: UIView = {
         let view = UIView()
         view.backgroundColor = UIColor.PersonalLight.light
-        view.layer.cornerRadius = 20
+        view.layer.cornerRadius = 24
         view.translatesAutoresizingMaskIntoConstraints = false
         return view
     }()

--- a/Quick-Kick/ViewContorller/MyPageViewController.swift
+++ b/Quick-Kick/ViewContorller/MyPageViewController.swift
@@ -6,7 +6,6 @@
 //
 
 import UIKit
-import CoreData
 
 class MyPageViewController: UIViewController {
     
@@ -26,26 +25,13 @@ class MyPageViewController: UIViewController {
         return button
     }()
     
-    // MARK: - Core Data
-    private var kickboardData: [Kickboard] = []
-    
     // MARK: - Lifecycle
     override func viewDidLoad() {
         super.viewDidLoad()
         viewTapAction()
         setupUI()
-        loadKickboards()
         configureSections()
         logoutButton.addTarget(self, action: #selector(handleLogout), for: .touchUpInside)
-    }
-    
-    // MARK: - Core Data: Load Kickboards
-    private func loadKickboards() {
-        do {
-            kickboardData = try CoreDataManager.shared.context.fetch(Kickboard.fetchRequest())
-        } catch {
-            print("킥보드 데이터를 불러오는 데 실패했습니다: \(error)")
-        }
     }
     
     // MARK: - Setup UI
@@ -95,17 +81,7 @@ class MyPageViewController: UIViewController {
     // MARK: - Configure Sections
     private func configureSections() {
         // 프로필 설정
-        if let user = UserDefaultsManager.shared.getUser() {
-            profileView.configure(name: user.nickName, email: user.email)
-        } else {
-            profileView.configure(name: "User1", email: "user1234@gmail.com")
-        }
-        
-        profileView.onNameChange = { newName in
-            var user = UserDefaultsManager.shared.getUser() ?? User(email: "user1234@gmail.com", password: "")
-            user.nickName = newName
-            UserDefaultsManager.shared.saveUser(user)
-        }
+        profileView.configure(name: "User1", email: "user1234@gmail.com")
         
         // 내가 등록한 킥보드 섹션
         kickboardSectionView.configure {
@@ -114,18 +90,18 @@ class MyPageViewController: UIViewController {
             self.navigationController?.pushViewController(detailVC, animated: true)
         }
         
-        // 히스토리 섹션 설정
-        let historyList = kickboardData.filter { $0.startTime != nil && $0.endTime != nil }
-        historySectionView.configure(with: historyList)
+        // 히스토리 섹션 더미 데이터 설정
+        let dummyHistories = [
+            ("24.12.01", "15:00 - 15:30"),
+            ("24.12.01", "15:00 - 15:30"),
+            ("24.12.01", "15:00 - 15:30")
+        ]
+        historySectionView.configure(with: dummyHistories)
     }
 
-    
     // MARK: - Logout Action
-    // 로그아웃 액션
     @objc private func handleLogout() {
-        UserDefaultsManager.shared.setLoggedOut()
         print("로그아웃 성공")
-        // 로그아웃 후 화면 전환 로직 추가
     }
     
     private func viewTapAction() {


### PR DESCRIPTION
# 개요
더미 데이터 추가
"킥보드 이용 내역" 섹션에 더미 데이터를 추가하여 화면에 표시되도록 구현:
let histories = [
    ("24.12.01", "15:00 - 15:30"),
    ("24.12.01", "15:00 - 15:30"),
    ("24.12.01", "15:00 - 15:30")
]
historySectionView.configure(with: histories)
해당 더미 데이터는 고정된 값으로 설정

## 추가 or 변경사항 
**UI 레이아웃 조정**
"킥보드 이용 내역" 섹션 아래에 흰색 박스(코너 반경 24)를 생성하고, 좌측에 QuickBoard 이미지를, 우측에는 날짜 및 시간 정보를 표시.
박스 간 간격을 일정하게 유지하여 깔끔한 UI 디자인을 구현.
더미 데이터가 각 박스에 바인딩되어 테스트 가능한 상태로 완성.
**변경된 화면**
각 데이터가 아래와 같은 형식으로 UI에 반영:
날짜: 24.12.01
운행 시간: 15:00 - 15:30
이미지: 좌측에 QuickBoard 아이콘 배치