### PR TITLE
fix: 텍스트 자동완성 기능 해제 & 아이디 저장 기능 수정

### DIFF
--- a/Quick-Kick/Managers/UserDefaultsManager.swift
+++ b/Quick-Kick/Managers/UserDefaultsManager.swift
@@ -14,6 +14,7 @@ enum UserDefaultsKeys {
     static let autoLoginOption = "AutoLoginOption"
     static let rememberIDOption = "RememberIDOption"
     static let onboarded = "Onboarded"
+    static let recentEmail = "RecentEmail"
 }
 
 // MARK: - Protocol
@@ -24,6 +25,7 @@ protocol UserDataManageable {
     var autoLoginOption: Bool { get set }
     var rememberIDOption: Bool { get set }
     var onboarded: Bool { get set }
+    var recentEmail: String { get set }
     func setLoggedOut()
 }
 
@@ -76,6 +78,7 @@ struct User: Codable {
 final class UserDefaultsManager: UserDataManageable {
     
   static let shared = UserDefaultsManager()
+    
   private init() {}
     var isLoggedIn: Bool {
         get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.loginStatus) }
@@ -95,5 +98,10 @@ final class UserDefaultsManager: UserDataManageable {
     var onboarded: Bool {
         get { UserDefaults.standard.bool(forKey: UserDefaultsKeys.onboarded) }
         set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.onboarded) }
+    }
+    
+    var recentEmail: String {
+        get { UserDefaults.standard.string(forKey: UserDefaultsKeys.recentEmail) ?? "" }
+        set { UserDefaults.standard.set(newValue, forKey: UserDefaultsKeys.recentEmail)}
     }
  }

--- a/Quick-Kick/View/LoginView.swift
+++ b/Quick-Kick/View/LoginView.swift
@@ -217,8 +217,12 @@ extension LoginView {
     }
     // 화면 이동 시, 텍스트필드 초기화
     func initTextFields() {
-        emailField.text = ""
-        passwordField.text = ""
+        if UserDefaultsManager.shared.rememberIDOption {
+            passwordField.text = ""
+        } else {
+            emailField.text = ""
+            passwordField.text = ""
+        }
     }
     
     // 자동 로그인 터치

--- a/Quick-Kick/View/LoginView.swift
+++ b/Quick-Kick/View/LoginView.swift
@@ -129,6 +129,8 @@ extension LoginView {
             make.height.equalTo(40)
             make.centerX.equalToSuperview()
         }
+        emailField.autocapitalizationType = .none
+        emailField.textContentType = .none
         
         passwordField.snp.makeConstraints { make in
             make.top.equalTo(emailField.snp.bottom).offset(10)
@@ -138,6 +140,7 @@ extension LoginView {
         }
         passwordField.isSecureTextEntry = true
         passwordField.textContentType = .none
+        passwordField.autocapitalizationType = .none
                 
         autoLoginOption.snp.makeConstraints { make in
             make.top.equalTo(passwordField.snp.bottom).offset(10)

--- a/Quick-Kick/View/SignUpView.swift
+++ b/Quick-Kick/View/SignUpView.swift
@@ -74,6 +74,8 @@ extension SignUpView {
             make.height.equalTo(40)
             make.centerX.equalToSuperview()
         }
+        emailField.autocapitalizationType = .none
+        emailField.textContentType = .none
         
         passwordField.snp.makeConstraints { make in
             make.top.equalTo(emailField.snp.bottom).offset(25)
@@ -83,6 +85,7 @@ extension SignUpView {
         }
         passwordField.isSecureTextEntry = true
         passwordField.textContentType = .none
+        passwordField.autocapitalizationType = .none
         
         confermPasswordField.snp.makeConstraints { make in
             make.top.equalTo(passwordField.snp.bottom).offset(25)
@@ -92,6 +95,7 @@ extension SignUpView {
         }
         confermPasswordField.isSecureTextEntry = true
         confermPasswordField.textContentType = .none
+        confermPasswordField.autocapitalizationType = .none
         
         signUpButton.snp.makeConstraints { make in
             make.top.equalTo(confermPasswordField.snp.bottom).offset(100)

--- a/Quick-Kick/ViewContorller/LoginViewController.swift
+++ b/Quick-Kick/ViewContorller/LoginViewController.swift
@@ -48,6 +48,12 @@ extension LoginViewController: LoginViewDelegate {
     
     // 로그인 버튼 터치 시
     func didLoginButtonTapped(_ email: String, _ password: String) {
+        if isValidEmail(email: email) {
+            UserDefaultsManager.shared.recentEmail = email
+        } else {
+            showAlert(message: "이메일을 확인해주세요!")
+        }
+        
         if isCorrectInfo(email: email, password: password) {
             login()
             loginView.showOnboardingPage()
@@ -121,6 +127,11 @@ extension LoginViewController {
         } else {
             return false
         }
+    }
+    // 이메일 형태 확인
+    private func isValidEmail(email: String) -> Bool {
+        let emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"
+        return NSPredicate(format: "SELF MATCHES %@", emailRegex).evaluate(with: email)
     }
     // 로그인 시 동작할 함수
     private func login() {

--- a/Quick-Kick/ViewContorller/LoginViewController.swift
+++ b/Quick-Kick/ViewContorller/LoginViewController.swift
@@ -80,8 +80,8 @@ extension LoginViewController: LoginViewDelegate {
     
     // 아이디 저장 옵션 시, 동작할 함수
     func getEmailTextField() {
-        guard let user = UserDefaultsManager.shared.getUser() else { return }
-        loginView.setEmailFieldText(email: user.email)
+        let email = UserDefaultsManager.shared.recentEmail
+        loginView.setEmailFieldText(email: email)
     }
     
     // 회원가입 버튼 터치 시

--- a/Quick-Kick/ViewContorller/SignUpViewController.swift
+++ b/Quick-Kick/ViewContorller/SignUpViewController.swift
@@ -40,6 +40,7 @@ extension SignUpViewController: SignUpViewDelegate {
         case .success:
             print("Success")
             UserDefaultsManager.shared.saveUser(User(email: email, password: pass))
+            UserDefaultsManager.shared.recentEmail = email
             if let targetVC = navigationController?.viewControllers.first(where: { $0 is LoginViewController }) {
                 navigationController?.popToViewController(targetVC, animated: true)
             } else {


### PR DESCRIPTION
# 개요
- `UITextField`에서 첫 문자를 대문자로 변경하는 기능을 해제했습니다.
- `UITextField`에서 자동완성 기능을 해제했습니다.
- 아이디 저장 기능의 로직을 수정했습니다.

## 에러 드리블
- `UITextField`의 설정들을 변경해주었습니다.
- 사용자의 이용흐름상 부자연스러웠던 아이디 저장 기능을 수정하였습니다.

close #58 