### PR TITLE
bug: 킥보드 모달 버그

### DIFF
--- a/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
+++ b/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
@@ -12,12 +12,30 @@ final class SearchKickboardViewController: UIViewController {
     override func loadView() {
         super.loadView()
         
+        searchKickboardView.searchKickboardMapView.rentKickboardModalView.alertDelegate = self
         fetchKickboards()
         view = searchKickboardView
+        
     }
     
     private func fetchKickboards() {
         let kickboards = CoreDataManager.shared.fetch()
         searchKickboardView.deliverKickboardsData(kickboards)
+    }
+}
+
+extension SearchKickboardViewController: RentKickboardModalViewAlertDelegate {
+    func showAlert(title: String, completion: @escaping () -> Void) {
+        let alert = UIAlertController(title: title, message: nil, preferredStyle: .alert)
+
+        let success = UIAlertAction(title: "확인", style: .default) { _ in
+            completion()
+        }
+        let cancel = UIAlertAction(title: "취소", style: .default)
+
+        alert.addAction(success)
+        alert.addAction(cancel)
+
+        present(alert, animated: true, completion: nil)
     }
 }

--- a/Quick-Kick/SearchKickboard/View/RentKickboardModalView.swift
+++ b/Quick-Kick/SearchKickboard/View/RentKickboardModalView.swift
@@ -10,6 +10,10 @@ protocol RentKickboardModalViewDelegate: AnyObject {
     func didUpdateKickboardStatus(_ kickboard: Kickboard)
 }
 
+protocol RentKickboardModalViewAlertDelegate: AnyObject {
+    func showAlert(title: String, completion: @escaping () -> Void)
+}
+
 final class RentKickboardModalView: UIView {
     private(set) var kickboard: Kickboard?
     
@@ -65,6 +69,7 @@ final class RentKickboardModalView: UIView {
     }()
     
     weak var delegate: RentKickboardModalViewDelegate?
+    weak var alertDelegate: RentKickboardModalViewAlertDelegate?
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -105,15 +110,22 @@ final class RentKickboardModalView: UIView {
     @objc
     private func rentButtonTapped() {
         if self.kickboard?.startTime == nil {
-            self.kickboard?.startTime = Date()
-            self.rentButton.setTitle("이용 종료", for: .normal)
+            alertDelegate?.showAlert(title: "킥보드를 이용하시겠습니까?", completion: {
+                self.kickboard?.startTime = Date()
+                self.rentButton.setTitle("이용 종료", for: .normal)
+                if let kickboard = self.kickboard {
+                    self.delegate?.didUpdateKickboardStatus(kickboard)
+                }
+            })
         } else {
-            self.kickboard?.endTime = Date()
-            self.kickboard?.startTime = nil
-            self.rentButton.setTitle("이용 시작", for: .normal)
-        }
-        if let kickboard = self.kickboard {
-            delegate?.didUpdateKickboardStatus(kickboard)
+            alertDelegate?.showAlert(title: "이용을 종료하시겠습니까?", completion: {
+                self.kickboard?.endTime = Date()
+                self.kickboard?.startTime = nil
+                self.rentButton.setTitle("이용 시작", for: .normal)
+                if let kickboard = self.kickboard {
+                    self.delegate?.didUpdateKickboardStatus(kickboard)
+                }
+            })
         }
     }
 }

--- a/Quick-Kick/SearchKickboard/View/RentKickboardModalView.swift
+++ b/Quick-Kick/SearchKickboard/View/RentKickboardModalView.swift
@@ -6,6 +6,10 @@
 //
 import UIKit
 
+protocol RentKickboardModalViewDelegate: AnyObject {
+    func didUpdateKickboardStatus(_ kickboard: Kickboard)
+}
+
 final class RentKickboardModalView: UIView {
     private(set) var kickboard: Kickboard?
     
@@ -60,6 +64,8 @@ final class RentKickboardModalView: UIView {
         return stackView
     }()
     
+    weak var delegate: RentKickboardModalViewDelegate?
+    
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupModalView()
@@ -103,7 +109,11 @@ final class RentKickboardModalView: UIView {
             self.rentButton.setTitle("이용 종료", for: .normal)
         } else {
             self.kickboard?.endTime = Date()
+            self.kickboard?.startTime = nil
             self.rentButton.setTitle("이용 시작", for: .normal)
+        }
+        if let kickboard = self.kickboard {
+            delegate?.didUpdateKickboardStatus(kickboard)
         }
     }
 }

--- a/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
+++ b/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
@@ -175,6 +175,11 @@ extension SearchKickboardMapView {
             $0.bottom.equalToSuperview().offset(-10)
             $0.leading.trailing.equalToSuperview().inset(10)
         }
+        
+        UIView.animate(withDuration: 0.3, delay: 0, options: .curveEaseOut) {
+            self.rentKickboardModalView.alpha = 1
+            self.rentKickboardModalView.transform = .identity
+        }
     }
     
     override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {

--- a/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
+++ b/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
@@ -168,7 +168,9 @@ extension SearchKickboardMapView {
     
     private func showModal(for kickboard: Kickboard) {
         rentKickboardModalView.setupKickboardData(kickboard)
+        rentKickboardModalView.delegate = self
         self.addSubview(rentKickboardModalView)
+        
         rentKickboardModalView.snp.makeConstraints {
             $0.bottom.equalToSuperview().offset(-10)
             $0.leading.trailing.equalToSuperview().inset(10)
@@ -205,5 +207,29 @@ extension SearchKickboardMapView {
             }
         }
         return hitView
+    }
+}
+
+extension SearchKickboardMapView: RentKickboardModalViewDelegate {
+    func didUpdateKickboardStatus(_ kickboard: Kickboard) {
+        // 킥보드 이용중인 경우
+        if kickboard.startTime != nil {
+            // 마커 찾기
+            for annotation in annotations {
+                guard let kickboardAnnotation = annotation as? KickboardAnnotation,
+                      kickboardAnnotation.kickboard.nickName == kickboard.nickName else {
+                    continue
+                }
+                removeAnnotation(annotation)
+                break
+            }
+        }
+        // 킥보드 이용 종료
+        else if kickboard.endTime != nil {
+            // 모달 제거
+            rentKickboardModalView.removeFromSuperview()
+            let annotation = KickboardAnnotation(kickboard: kickboard)
+            addAnnotation(annotation)
+        }
     }
 }

--- a/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
+++ b/Quick-Kick/SearchKickboard/View/SearchKickboardMapView.swift
@@ -18,7 +18,7 @@ final class SearchKickboardMapView: MKMapView {
     
     private var kickboards: [Kickboard]?
     weak var mapViewDelegate: SearchKickboardMapViewDelegate?
-    private var rentKickboardModalView = RentKickboardModalView()
+    private(set) var rentKickboardModalView = RentKickboardModalView()
     
     private let gangnamStation = CLLocation(
         latitude: 37.498095,


### PR DESCRIPTION
# 개요
- 이용중인 킥보드는 지도에 보이지 않아야하는데 보이는 버그 해결
- 이용 종료 후에 모달이 사라져야 하는데 계속 떠있는 버그 해결
- 이용 시작/종료 시 alert창 호출

| 이용중 킥보드 마커 사라지기 | 이용 종료 후 모달 사라지기 |
| --- | --- | 
| <img src="https://github.com/user-attachments/assets/74f41fd7-3713-4727-be12-265362ee22e7" width="300"> | <img src="https://github.com/user-attachments/assets/f71e28ca-bf58-4b3a-8485-d5ec6ffaa4ee" width="300"> |


## 에러 드리블
킥보드 이용이 시작되면 해당 마커가 사라져야 하는데

| 이용이 종료되고 나서 마커가 사라짐 | 이용이 시작되도 마커가 사리지지 않음 |
| --- | --- | 
| <img src="https://github.com/user-attachments/assets/d721d6ff-5c48-4416-8e9b-2fd66785233a" width="300"> | <img src="https://github.com/user-attachments/assets/e320272e-57a8-4e8c-ab7c-450b61d28ad6" width="300"> |


- 원인: 이스케이핑 클로저 내부에서 킥보드의 상태를 변경하는데, 마커의 상태 변경은 클로저 밖에서 일어나 
  마커 상태를 변경할 때 변경된 킥보드 상태가 반영되지 않는 경우 생김. 
- 해결: 클로저 내부에서 마커 상태 변경 메서드 호출

