### PR TITLE
bug: 킥보드 등록 후 킥보드 찾기 이동 시 등록 킥보드 보이지 않는 오류 해결

### DIFF
--- a/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
+++ b/Quick-Kick/SearchKickboard/Controller/SearchKickboardViewController.swift
@@ -9,13 +9,15 @@ import UIKit
 final class SearchKickboardViewController: UIViewController {
     let searchKickboardView = SearchKickboardView()
     
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        fetchKickboards()
+    }
+    
     override func loadView() {
         super.loadView()
-        
         searchKickboardView.searchKickboardMapView.rentKickboardModalView.alertDelegate = self
-        fetchKickboards()
         view = searchKickboardView
-        
     }
     
     private func fetchKickboards() {


### PR DESCRIPTION
# 개요

| 킥보드 등록 후 찾기 탭에서 보이지 않는 현상 | 킥보드 등록 후 찾기 탭 이동시 정상적으로 보이도록 수정 |
| --- | --- |
| ![킥보드등록버그](https://github.com/user-attachments/assets/3d1249a7-f5b1-4214-8be1-84972208f03a) | ![킥보드등록버그해결](https://github.com/user-attachments/assets/6cd6d600-b4a5-4391-8ab7-df45c7daadb4) |


## 에러 드리블

- 원인: loadView에서 데이터 fetch가 이루어져 뷰 최초 생성시에만 데이터가 fetch되는 것
- 해결: viewWillAppear에서 뷰가 나타날 때마다 데이터 fetch가 이루어지도록 수정

## 추가 or 변경사항 

- 기존: loadView에서 데이터 fetch
- 수정: viewWillAppear에서 데이터 fetch
