### PR TITLE
fix: 마이페이지 내용 수정 + 온보딩 화면 분기처리

### DIFF
--- a/Quick-Kick/AppDelegate.swift
+++ b/Quick-Kick/AppDelegate.swift
@@ -24,6 +24,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     private func setInitialView() -> UIViewController {
         print("isLoggedIn:\(UserDefaultsManager.shared.isLoggedIn)")
         print("autoLoginOption:\(UserDefaultsManager.shared.autoLoginOption)")
+        print("onboarded:\(UserDefaultsManager.shared.onboarded)")
         if UserDefaultsManager.shared.isLoggedIn {
             return ViewController()
         } else if UserDefaultsManager.shared.autoLoginOption {

--- a/Quick-Kick/Managers/UserDefaultsManager.swift
+++ b/Quick-Kick/Managers/UserDefaultsManager.swift
@@ -9,7 +9,7 @@ import Foundation
 
 // MARK: - Key 관리 열거형
 enum UserDefaultsKeys {
-    static let user = "user"
+    static let user = "User"
     static let loginStatus = "LoginStatus"
     static let autoLoginOption = "AutoLoginOption"
     static let rememberIDOption = "RememberIDOption"
@@ -71,7 +71,7 @@ extension UserDataManageable {
 struct User: Codable {
     var email: String
     var password: String
-    var nickName: String = "User1"
+    var nickName: String = "4과해요나한테"
 }
 
 // MARK: - UserDefaultsManager

--- a/Quick-Kick/Managers/UserDefaultsManager.swift
+++ b/Quick-Kick/Managers/UserDefaultsManager.swift
@@ -71,7 +71,7 @@ extension UserDataManageable {
 struct User: Codable {
     var email: String
     var password: String
-    var nickName: String = "4과해요나한테"
+    var nickName: String = "킥보드무4고"
 }
 
 // MARK: - UserDefaultsManager

--- a/Quick-Kick/View/LoginView.swift
+++ b/Quick-Kick/View/LoginView.swift
@@ -247,6 +247,15 @@ extension LoginView {
         }
     }
     
+    func changeViewController() {
+        UserDefaultsManager.shared.onboarded = true
+        DispatchQueue.main.async {
+            UIView.transition(with: self.window!, duration: 0.5, options: .transitionCrossDissolve) {
+                self.window?.rootViewController = UINavigationController(rootViewController: ViewController())
+            }
+        }
+    }
+    
     // 회원가입 터치
     @objc func signupButtonTapped() {
         delegate?.didSignUpButtonTapped()

--- a/Quick-Kick/ViewContorller/LoginViewController.swift
+++ b/Quick-Kick/ViewContorller/LoginViewController.swift
@@ -56,7 +56,11 @@ extension LoginViewController: LoginViewDelegate {
         
         if isCorrectInfo(email: email, password: password) {
             login()
-            loginView.showOnboardingPage()
+            if !UserDefaultsManager.shared.onboarded {
+                loginView.showOnboardingPage()
+            } else {
+                loginView.changeViewController()
+            }
         } else {
             showAlert(message: "입력 값을 확인해주세요!")
             print("로그인 실패")

--- a/Quick-Kick/ViewContorller/MyPageViewController.swift
+++ b/Quick-Kick/ViewContorller/MyPageViewController.swift
@@ -87,8 +87,10 @@ class MyPageViewController: UIViewController {
     
     // MARK: - Configure Sections
     private func configureSections() {
+        
+        guard let user = UserDefaultsManager.shared.getUser() else { return }
         // 프로필 설정
-        profileView.configure(name: "User1", email: "user1234@gmail.com")
+        profileView.configure(name: user.nickName, email: user.email)
         
         // 내가 등록한 킥보드 섹션
         kickboardSectionView.configure {

--- a/Quick-Kick/ViewContorller/MyPageViewController.swift
+++ b/Quick-Kick/ViewContorller/MyPageViewController.swift
@@ -101,9 +101,9 @@ class MyPageViewController: UIViewController {
         
         // 히스토리 섹션 더미 데이터 설정
         let dummyHistories = [
-            ("24.12.01", "15:00 - 15:30"),
-            ("24.12.01", "15:00 - 15:30"),
-            ("24.12.01", "15:00 - 15:30")
+            ("24.12.19", "08:30 - 09:00"),
+            ("24.12.19", "15:00 - 15:30"),
+            ("24.12.20", "03:00 - 04:00")
         ]
         historySectionView.configure(with: dummyHistories)
     }


### PR DESCRIPTION
# 개요
<div>
<img width="200" src="https://github.com/user-attachments/assets/5826cc41-ed63-430f-a570-57da14ecada6">
</div>

## 에러 드리블
- 작업을 위해서 `MockData`로 마이페이지가 표시되어있었습니다.
- `UserDefaults`에 저장된 값을 표시할 수 있게 코드를 수정하였습니다.

```swift
        guard let user = UserDefaultsManager.shared.getUser() else { return }
        // 프로필 설정
        profileView.configure(name: user.nickName, email: user.email)
```

- 확인 과정에서 온보딩 화면이 최초 1회가 아닌 지속 표시되는 점을 확인하였습니다.
- 로그인 성공 시, `onBoarded` 여부에 따라서 온보딩 뷰를 보여줄지 분기처리로 해결하였습니다.

```swift
if isCorrectInfo(email: email, password: password) {
            login()
            if !UserDefaultsManager.shared.onboarded {
                loginView.showOnboardingPage()
            } else {
                loginView.changeViewController()
            }
        } else {
            showAlert(message: "입력 값을 확인해주세요!")
            print("로그인 실패")
            initTextFields()
        }
```

- 직관성을 위해서 더미 데이터를 수정하였습니다.

```swift
        // 히스토리 섹션 더미 데이터 설정
        let dummyHistories = [
            ("24.12.19", "08:30 - 09:00"),
            ("24.12.19", "15:00 - 15:30"),
            ("24.12.20", "03:00 - 04:00")
        ]
```

close #66 